### PR TITLE
Remove containers when finished

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -75,7 +75,7 @@ done
 # Run the Docker container from the specified image
 if [ "$valid_command" = true ]; then
   docker pull bitoai/cra:latest >&2
-  exec docker run bitoai/cra:latest --mode=cli --pr_url $INPUT_PR --command "$INPUT_COMMAND" rest $docker_cmd_args
+  exec docker run --rm bitoai/cra:latest --mode=cli --pr_url $INPUT_PR --command "$INPUT_COMMAND" rest $docker_cmd_args
 else
   echo "$INPUT_COMMAND is not supported"
   exit 0  # Exit the script with a non-zero status code


### PR DESCRIPTION
To prevent the disk from filling up, the containers should probably be removed when they are finished.